### PR TITLE
This adds a hook so that the popup window gets notified when it is closed

### DIFF
--- a/egui-multiwin/src/tracked_window.rs
+++ b/egui-multiwin/src/tracked_window.rs
@@ -123,7 +123,8 @@ pub trait TrackedWindow<T> {
         true
     }
 
-    fn close_requested();
+    /// Lets the window know that it should close
+    fn close_requested(&mut self){}
 
     /// Sets whether or not the window is a root window. Does nothing by default
     fn set_root(&mut self, _root: bool) {}

--- a/egui-multiwin/src/tracked_window.rs
+++ b/egui-multiwin/src/tracked_window.rs
@@ -124,7 +124,7 @@ pub trait TrackedWindow<T> {
     }
 
     /// Lets the window know that it should close
-    fn close_requested(&mut self){}
+    fn close_requested(&mut self, c: &mut T){}
 
     /// Sets whether or not the window is a root window. Does nothing by default
     fn set_root(&mut self, _root: bool) {}
@@ -222,7 +222,7 @@ fn handle_event<COMMON, U>(
             }
 
             if let winit::event::WindowEvent::CloseRequested = event {
-                s.close_requested();
+                s.close_requested(c);
                 control_flow = winit::event_loop::ControlFlow::Exit;
             }
 

--- a/egui-multiwin/src/tracked_window.rs
+++ b/egui-multiwin/src/tracked_window.rs
@@ -123,6 +123,8 @@ pub trait TrackedWindow<T> {
         true
     }
 
+    fn close_requested();
+
     /// Sets whether or not the window is a root window. Does nothing by default
     fn set_root(&mut self, _root: bool) {}
 
@@ -219,6 +221,7 @@ fn handle_event<COMMON, U>(
             }
 
             if let winit::event::WindowEvent::CloseRequested = event {
+                s.close_requested();
                 control_flow = winit::event_loop::ControlFlow::Exit;
             }
 


### PR DESCRIPTION
Using this method close_requested() you can set some data on the AppCommon struct to notify the root window that the popupwindow has been closed.